### PR TITLE
Add Folia scheduler support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,15 @@
 https://hub.spigotmc.org/javadocs/spigot/org/bukkit/block/Block.html#getDrops(org.bukkit.inventory.ItemStack,org.bukkit.entity.Entity)
 https://hub.spigotmc.org/javadocs/spigot/org/bukkit/block/Block.html#isPreferredTool(org.bukkit.inventory.ItemStack)
 https://hub.spigotmc.org/javadocs/spigot/org/bukkit/block/Block.html#getBreakSpeed(org.bukkit.entity.Player)
+
+## Updating to Folia compatible BestTools
+
+This fork introduces support for [Folia](https://github.com/PaperMC/Folia) so the plugin can run on asynchronous servers. A custom `Scheduler` class automatically chooses between Folia schedulers and the Bukkit scheduler at runtime. All internal tasks now rely on this helper to remain compatible with both server types.
+
+Additional changes include:
+
+- **Paper API** – the project now depends on the Paper API instead of Spigot, providing Folia-ready scheduler classes.
+- **Scheduler integration** – `BestToolsListener`, `GUIHandler` and `RefillUtils` were updated to schedule their actions through the new `Scheduler` class.
+- **New file** – `src/main/java/de/jeff_media/BestTools/Scheduler.java` contains the implementation of the cross-compatible scheduler.
+
+Server owners upgrading should update their dependency to the Paper repository. Existing configurations remain the same, and the plugin will automatically switch scheduling implementations depending on the runtime environment.

--- a/pom.xml
+++ b/pom.xml
@@ -85,8 +85,8 @@
             <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
         </repository>
         <repository>
-            <id>spigot-repo</id>
-            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+            <id>papermc-repo</id>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
         </repository>
         <repository>
             <id>CodeMC</id>
@@ -110,8 +110,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot-api</artifactId>
+            <groupId>io.papermc.paper</groupId>
+            <artifactId>paper-api</artifactId>
             <version>1.21.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>

--- a/src/main/java/de/jeff_media/BestTools/BestToolsListener.java
+++ b/src/main/java/de/jeff_media/BestTools/BestToolsListener.java
@@ -18,6 +18,8 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
+
+import de.jeff_media.BestTools.Scheduler;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
@@ -79,10 +81,10 @@ public class BestToolsListener implements Listener {
     public void onBreak(BlockBreakEvent event) {
         //System.out.println("BlockBreakEvent LISTENER");
         //System.out.println(event.getBlock());
-        Bukkit.getScheduler().runTaskLater(main, () -> {
+        Scheduler.runLater(() -> {
             Bukkit.getPluginManager().callEvent(new BestToolsNotifyEvent(event.getPlayer(), event.getBlock()));
             //Bukkit.getPluginManager().callEvent(new PlayerInteractEvent(event.getPlayer(), Action.LEFT_CLICK_BLOCK, event.getPlayer().getInventory().getItemInMainHand(),event.getBlock(),BlockFace.SELF,EquipmentSlot.HAND));
-        },1);
+        }, 1);
     }
 
     @EventHandler

--- a/src/main/java/de/jeff_media/BestTools/GUIHandler.java
+++ b/src/main/java/de/jeff_media/BestTools/GUIHandler.java
@@ -1,6 +1,8 @@
 package de.jeff_media.BestTools;
 
 import org.bukkit.Bukkit;
+
+import de.jeff_media.BestTools.Scheduler;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -174,8 +176,8 @@ public class GUIHandler implements Listener {
     void open(Player p) {
         Inventory inv = create(p);
         p.closeInventory();
-        Bukkit.getScheduler().runTask(main,() -> {
-           p.openInventory(inv);
+        Scheduler.run(() -> {
+            p.openInventory(inv);
         });
     }
 

--- a/src/main/java/de/jeff_media/BestTools/RefillUtils.java
+++ b/src/main/java/de/jeff_media/BestTools/RefillUtils.java
@@ -2,6 +2,8 @@ package de.jeff_media.BestTools;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
+
+import de.jeff_media.BestTools.Scheduler;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
@@ -57,7 +59,7 @@ public class RefillUtils {
     }
 
     void refillStack(Inventory inv, int source, int dest, ItemStack stack) {
-        Bukkit.getScheduler().runTask(main, () -> {
+        Scheduler.run(() -> {
             if(inv.getItem(source)==null) return;
             if(!inv.getItem(source).equals(stack)) {
                 main.debug("Refill failed, because source ItemStack has changed. Aborting Refill to prevent item loss.");

--- a/src/main/java/de/jeff_media/BestTools/Scheduler.java
+++ b/src/main/java/de/jeff_media/BestTools/Scheduler.java
@@ -1,0 +1,222 @@
+package de.jeff_media.BestTools;
+
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.scheduler.BukkitTask;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.bukkit.Bukkit.getLogger;
+
+/**
+ * Utility class for scheduling tasks with optional Folia support.
+ */
+public final class Scheduler {
+
+    private static final boolean isFolia;
+    static {
+        boolean folia;
+        try {
+            Class.forName("io.papermc.paper.threadedregions.scheduler.GlobalRegionScheduler");
+            folia = true;
+            getLogger().warning("Scheduler You are running FOLIA");
+        } catch (ClassNotFoundException e) {
+            folia = false;
+            getLogger().warning("Scheduler You are running BUKKIT");
+        }
+        isFolia = folia;
+    }
+
+    /**
+     * Runs a task on the global scheduler.
+     *
+     * @param runnable task to run
+     */
+    public static void run(Runnable runnable) {
+        if (isFolia) {
+            Bukkit.getGlobalRegionScheduler().execute(Main.getInstance(), runnable);
+        } else {
+            Bukkit.getScheduler().runTask(Main.getInstance(), runnable);
+        }
+    }
+
+    /**
+     * Runs a task after a delay using the global scheduler.
+     *
+     * @param runnable   task to run
+     * @param delayTicks delay in ticks
+     * @return scheduled task wrapper
+     */
+    public static Task runLater(Runnable runnable, long delayTicks) {
+        if (delayTicks <= 0) {
+            run(runnable);
+            return new Task(null);
+        }
+        if (isFolia) {
+            return new Task(Bukkit.getGlobalRegionScheduler().runDelayed(Main.getInstance(), t -> runnable.run(), delayTicks));
+        }
+        return new Task(Bukkit.getScheduler().runTaskLater(Main.getInstance(), runnable, delayTicks));
+    }
+
+    /**
+     * Runs a repeating task on the global scheduler.
+     *
+     * @param runnable    task to run
+     * @param delayTicks  delay before first run
+     * @param periodTicks period between runs
+     * @return scheduled task wrapper
+     */
+    public static Task runTimer(Runnable runnable, long delayTicks, long periodTicks) {
+        if (isFolia) {
+            return new Task(Bukkit.getGlobalRegionScheduler().runAtFixedRate(Main.getInstance(), t -> runnable.run(), delayTicks < 1 ? 1 : delayTicks, periodTicks));
+        }
+        return new Task(Bukkit.getScheduler().runTaskTimer(Main.getInstance(), runnable, delayTicks, periodTicks));
+    }
+
+    // -------------------------------------------------------------------
+    // ASYNC METHODS
+    // -------------------------------------------------------------------
+
+    /**
+     * Runs a task asynchronously.
+     *
+     * @param runnable task to run
+     */
+    public static void runAsync(Runnable runnable) {
+        if (isFolia) {
+            Bukkit.getAsyncScheduler().runNow(Main.getInstance(), t -> runnable.run());
+        } else {
+            Bukkit.getScheduler().runTaskAsynchronously(Main.getInstance(), runnable);
+        }
+    }
+
+    /**
+     * Runs a task asynchronously after a delay.
+     *
+     * @param runnable   task to run
+     * @param delayTicks delay in ticks
+     * @return scheduled task wrapper
+     */
+    public static Task runAsyncLater(Runnable runnable, long delayTicks) {
+        if (delayTicks <= 0) {
+            runAsync(runnable);
+            return new Task(null);
+        }
+        if (isFolia) {
+            return new Task(Bukkit.getAsyncScheduler().runDelayed(Main.getInstance(), t -> runnable.run(), delayTicks * 50L, TimeUnit.MILLISECONDS));
+        }
+        return new Task(Bukkit.getScheduler().runTaskLaterAsynchronously(Main.getInstance(), runnable, delayTicks));
+    }
+
+    /**
+     * Runs a repeating asynchronous task.
+     *
+     * @param runnable    task to run
+     * @param delayTicks  delay before first run
+     * @param periodTicks period between runs
+     * @return scheduled task wrapper
+     */
+    public static Task runAsyncTimer(Runnable runnable, long delayTicks, long periodTicks) {
+        if (isFolia) {
+            return new Task(Bukkit.getAsyncScheduler().runAtFixedRate(Main.getInstance(), t -> runnable.run(), (delayTicks < 1 ? 1 : delayTicks) * 50L, periodTicks * 50L, TimeUnit.MILLISECONDS));
+        }
+        return new Task(Bukkit.getScheduler().runTaskTimerAsynchronously(Main.getInstance(), runnable, delayTicks, periodTicks));
+    }
+
+    // -------------------------------------------------------------------
+    // REGION METHODS
+    // -------------------------------------------------------------------
+
+    /**
+     * Runs a task in a region context.
+     *
+     * @param location world location
+     * @param runnable task to run
+     */
+    public static void run(Location location, Runnable runnable) {
+        if (isFolia) {
+            Bukkit.getRegionScheduler().execute(Main.getInstance(), location, runnable);
+        } else {
+            Bukkit.getScheduler().runTask(Main.getInstance(), runnable);
+        }
+    }
+
+    /**
+     * Runs a task after a delay in a region context.
+     *
+     * @param location   world location
+     * @param runnable   task to run
+     * @param delayTicks delay in ticks
+     * @return scheduled task wrapper
+     */
+    public static Task runLater(Location location, Runnable runnable, long delayTicks) {
+        if (delayTicks <= 0) {
+            run(location, runnable);
+            return new Task(null);
+        }
+        if (isFolia) {
+            return new Task(Bukkit.getRegionScheduler().runDelayed(Main.getInstance(), location, t -> runnable.run(), delayTicks));
+        }
+        return new Task(Bukkit.getScheduler().runTaskLater(Main.getInstance(), runnable, delayTicks));
+    }
+
+    /**
+     * Runs a repeating task in a region context.
+     *
+     * @param location    world location
+     * @param runnable    task to run
+     * @param delayTicks  delay before first run
+     * @param periodTicks period between runs
+     * @return scheduled task wrapper
+     */
+    public static Task runTimer(Location location, Runnable runnable, long delayTicks, long periodTicks) {
+        if (isFolia) {
+            return new Task(Bukkit.getRegionScheduler().runAtFixedRate(Main.getInstance(), location, t -> runnable.run(), delayTicks < 1 ? 1 : delayTicks, periodTicks));
+        }
+        return new Task(Bukkit.getScheduler().runTaskTimer(Main.getInstance(), runnable, delayTicks, periodTicks));
+    }
+
+    /**
+     * @return true if the server runs Folia
+     */
+    public static boolean isFolia() {
+        return isFolia;
+    }
+
+    /**
+     * Placeholder method for cancelling current task.
+     */
+    public static void cancelCurrentTask() {
+    }
+
+    /**
+     * Wrapper for scheduled tasks.
+     */
+    public static class Task {
+
+        private final Object foliaTask;
+        private final BukkitTask bukkitTask;
+
+        Task(Object foliaTask) {
+            this.foliaTask = foliaTask;
+            this.bukkitTask = null;
+        }
+
+        Task(BukkitTask bukkitTask) {
+            this.bukkitTask = bukkitTask;
+            this.foliaTask = null;
+        }
+
+        /**
+         * Cancel the task.
+         */
+        public void cancel() {
+            if (foliaTask != null) {
+                ((ScheduledTask) foliaTask).cancel();
+            } else if (bukkitTask != null) {
+                bukkitTask.cancel();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a new Scheduler utility that detects Folia and delegates to the correct scheduler
- update GUIHandler, BestToolsListener and RefillUtils to use the new scheduler
- switch from Spigot to Paper API for Folia support
- document the upgrade steps in the README

## Testing
- `mvn -q -DskipTests=false test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d61ce3f208332874adb64afd63c99